### PR TITLE
Find 'parent'-references

### DIFF
--- a/cli/args.js
+++ b/cli/args.js
@@ -45,8 +45,11 @@ module.exports = require('yargs')
         'default': 'mysql'
     })
     .option('strip-suffix', {
-        alias: 's',
         describe: 'Remove a suffix from table names when generating',
+        type: 'array'
+    })
+    .option('strip-prefix', {
+        describe: 'Remove a prefix from table names when generating',
         type: 'array'
     })
     .option('interactive', {

--- a/steps/find-references.js
+++ b/steps/find-references.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var log = require('../util/log');
 var filter = require('lodash/collection/filter');
 var snakeCase = require('lodash/string/snakeCase');
 var capitalize = require('lodash/string/capitalize');
@@ -19,7 +18,9 @@ function findReferencesForModel(model, models) {
 
     // Filter the columns that have a corresponding model
     return refs.reduce(function(references, col) {
-        var parts = snakeCase(col.name.substr(0, col.name.length - 2)).split('_');
+        var colName = col.name.substr(0, col.name.length - 2).replace(/^parent/, '');
+        var parts = snakeCase(colName).split('_');
+
         do {
             var name = parts.map(capitalize).join('');
 

--- a/steps/table-to-object.js
+++ b/steps/table-to-object.js
@@ -6,7 +6,11 @@ var capitalize = require('lodash/string/capitalize');
 var columnToObject = require('./column-to-object');
 
 function tableToObject(table, opts) {
-    var normalized = normalizeTableName(table.name, opts['strip-suffix']);
+    var normalized = normalizeTableName(table.name, {
+        suffix: opts['strip-suffix'],
+        prefix: opts['strip-prefix']
+    });
+
     var model = {
         name: getTypeName(normalized),
         description: table.comment,
@@ -29,10 +33,12 @@ function reduceColumn(fields, column) {
 }
 
 function normalizeTableName(name, strip) {
-    strip = strip || [];
-
-    strip.forEach(function(suffix) {
+    (strip.suffix || []).forEach(function(suffix) {
         name = name.replace(new RegExp(escapeRegExp(suffix) + '$'), '');
+    });
+
+    (strip.prefix || []).forEach(function(prefix) {
+        name = name.replace(new RegExp('^' + escapeRegExp(prefix)), '');
     });
 
     return name;


### PR DESCRIPTION
This PR looks for `parent`-references. That is, if a column is named `parentCategoryId` and there is a known model called `Category`, there will be created a `parentCategoryId` => `Parent` relation.

PR also adds a `--strip-prefix` option to match the `--strip-suffix` option. Removed the single character alias as it was getting hard to maintain.
