### PR TITLE
Add initial code generation

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 'use strict';
 
-var log = require('./util/log');
 var opts = require('./cli/args');
 var async = require('async');
 var prompts = require('./cli/prompts');
@@ -12,6 +11,8 @@ var steps = {
     getTables: require('./steps/table-list'),
     tableToObject: require('./steps/table-to-object'),
     findReferences: require('./steps/find-references'),
+    generateTypes: require('./steps/generate-types'),
+    outputData: require('./steps/output-data'),
 
     collect: {
         tableStructure: require('./steps/table-structure'),
@@ -55,6 +56,7 @@ function onTablesSelected(tables) {
 // When table data has been collected, build an object representation of them
 function onTableDataCollected(err, data) {
     bailOnError(err);
+    adapter.close();
 
     var tableName, models = {}, model;
     for (tableName in data.tableStructure) {
@@ -68,9 +70,9 @@ function onTableDataCollected(err, data) {
     }
 
     data.models = steps.findReferences(models);
+    data.types = steps.generateTypes(data, opts);
 
-    log.depth(data.models, 2);
-    adapter.close();
+    steps.outputData(data, opts);
 }
 
 function bail(err) {

--- a/cli/args.js
+++ b/cli/args.js
@@ -58,5 +58,40 @@ module.exports = require('yargs')
         type: 'boolean',
         'default': false
     })
+    .option('colors', {
+        alias: 'c',
+        describe: 'Colorize the code output',
+        type: 'boolean',
+        'default': false
+    })
+    .option('output-dir', {
+        describe: 'Print output into separate files within the given directory',
+        type: 'string'
+    })
+    .option('es6', {
+        describe: 'Output in ES6 format (const, import et all)',
+        type: 'boolean',
+        'default': false
+    })
+    .option('use-tabs', {
+        describe: 'Use tabs for indentation',
+        type: 'boolean',
+        'default': false
+    })
+    .option('tab-width', {
+        describe: 'Width of tabs',
+        type: 'number',
+        'default': 4
+    })
+    .option('quote', {
+        describe: 'Quote style (single/double)',
+        type: 'string',
+        'default': 'single'
+    })
+    .option('default-description', {
+        describe: 'The description to use for columns without a comment',
+        type: 'string',
+        'default': '@TODO DESCRIBE ME'
+    })
     .help('help')
     .argv;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   },
   "homepage": "https://github.com/vaffel/sql-to-graphql#readme",
   "dependencies": {
+    "ast-types": "^0.8.4",
     "async": "^1.3.0",
+    "cardinal": "^0.5.0",
     "graphql": "^0.1.3",
     "inquirer": "^0.8.5",
     "lodash": "^3.10.0",

--- a/steps/generate-types.js
+++ b/steps/generate-types.js
@@ -1,0 +1,160 @@
+'use strict';
+
+var capitalize = require('lodash/string/capitalize');
+var snakeCase = require('lodash/string/snakeCase');
+var b = require('ast-types').builders;
+
+var typeMap = {
+    'string': 'GraphQLString',
+    'integer': 'GraphQLInt',
+    'float': 'GraphQLFloat'
+};
+
+function generateTypes(data, opts) {
+    var types = {}, typesUsed;
+    for (var typeName in data.models) {
+        typesUsed = [];
+        types[typeName] = generateType(typeName, data.models[typeName]);
+        types[typeName].imports = typesUsed;
+    }
+
+    return types;
+
+    function addUsedType(type) {
+        if (typesUsed.indexOf(type) === -1) {
+            typesUsed.push(type);
+        }
+    }
+
+    function generateType(name, model) {
+        var fields = [], fieldNames = Object.keys(model.fields);
+        for (var fieldName in model.fields) {
+            fields.push(generateField(model.fields[fieldName]));
+
+            if (model.references[fieldName]) {
+                fields.push(generateReferenceField(
+                    fieldName,
+                    model.references[fieldName],
+                    fieldNames
+                ));
+            }
+        }
+
+        var typeDeclaration = b.objectExpression([
+            b.property('init', b.identifier('name'), b.literal(name)),
+            generateDescription(model.description),
+            b.property('init', b.identifier('fields'), b.objectExpression(fields))
+        ]);
+
+        return {
+            ast: buildVar(
+                name + 'Type',
+                b.newExpression(
+                    b.identifier('GraphQLObjectType'),
+                    [typeDeclaration]
+                ),
+                opts
+            )
+        };
+    }
+
+    function generateDescription(description) {
+        return b.property(
+            'init',
+            b.identifier('description'),
+            b.literal(description || opts.defaultDescription)
+        );
+    }
+
+    function generateField(field, type) {
+        return b.property(
+            'init',
+            b.identifier(field.name),
+            b.objectExpression([
+                b.property('init', b.identifier('type'), type || getType(field)),
+                generateDescription(field.description)
+            ])
+        );
+    }
+
+    function generateReferenceField(refName, refersTo, otherFields) {
+        var fieldName = refName.replace(/Id$/, '');
+
+        // If we collide with a different field name, add a "Ref"-suffix
+        if (otherFields.indexOf(fieldName) !== -1) {
+            fieldName += 'Ref';
+        }
+
+        var description = opts.defaultDescription;
+        if (fieldName.indexOf('parent') === 0) {
+            description += ' (parent ' + refersTo.name + ')';
+        } else {
+            description += ' (reference)';
+        }
+
+        var refTypeName = refersTo.name + 'Type';
+        addUsedType(refTypeName);
+
+        return generateField({
+            name: fieldName,
+            description: description
+        }, b.identifier(refTypeName));
+    }
+
+    function getType(field) {
+        if (field.type === 'enum') {
+            addUsedType('GraphQLEnumType');
+            return getEnum(field);
+        }
+
+        var type = typeMap[field.type];
+        var identifier = b.identifier(type);
+
+        addUsedType(type);
+
+        if (!field.isNullable) {
+            addUsedType('GraphQLNonNull');
+            return b.newExpression(b.identifier('GraphQLNonNull'), [identifier]);
+        }
+
+        return identifier;
+    }
+
+    function getEnum(field) {
+        var values = [], enumValue;
+        for (var name in field.values) {
+            enumValue = field.values[name];
+            values.push(b.property(
+                'init',
+                b.identifier(snakeCase(name).toUpperCase()),
+                b.objectExpression([
+                    b.property('init', b.identifier('value'), b.literal(enumValue.value)),
+                    generateDescription(enumValue.description)
+                ])
+            ));
+        }
+
+        var typeDeclaration = b.objectExpression([
+            b.property('init', b.identifier('name'), b.literal(capitalize(field.name))),
+            generateDescription(field.description),
+            b.property('init', b.identifier('values'), b.objectExpression(values))
+        ]);
+
+        return b.newExpression(
+            b.identifier('GraphQLEnumType'),
+            [typeDeclaration]
+        );
+    }
+
+    function buildVar(name, val) {
+        var varStyle = opts.es6 ? 'const' : 'var';
+        return b.variableDeclaration(varStyle, [
+            b.variableDeclarator(
+                b.identifier(name),
+                val
+            )
+        ]);
+    }
+}
+
+module.exports = generateTypes;

--- a/steps/output-data.js
+++ b/steps/output-data.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var b = require('ast-types').builders;
+var uniq = require('lodash/array/uniq');
+var merge = require('lodash/object/merge');
+var sortBy = require('lodash/collection/sortBy');
+var pluck = require('lodash/collection/pluck');
+var flatten = require('lodash/array/flatten');
+var printAst = require('../util/print-ast');
+var generateImports = require('../util/generate-imports');
+
+function outputData(data, opts) {
+    var options = merge({ skipLocalImports: !opts.outputDir }, opts);
+    var imports = uniq(flatten(pluck(data.types, 'imports')));
+    var typesAst = pluck(sortBy(data.types, 'imports.length'), 'ast');
+    var importsAst = generateImports(imports, options);
+
+    if (!opts.outputDir) {
+        return printAst(
+            b.program(importsAst.concat(typesAst)),
+            options
+        );
+    }
+
+    // Output to a directory, in other words: split stuff up
+    // @todo
+}
+
+module.exports = outputData;

--- a/steps/table-to-object.js
+++ b/steps/table-to-object.js
@@ -7,8 +7,8 @@ var columnToObject = require('./column-to-object');
 
 function tableToObject(table, opts) {
     var normalized = normalizeTableName(table.name, {
-        suffix: opts['strip-suffix'],
-        prefix: opts['strip-prefix']
+        suffix: opts.stripSuffix,
+        prefix: opts.stripPrefix
     });
 
     var model = {

--- a/util/generate-imports.js
+++ b/util/generate-imports.js
@@ -1,0 +1,117 @@
+'use strict';
+
+var b = require('ast-types').builders;
+var path = require('path');
+
+function generateImports(imports, opts) {
+    var graphql = ['GraphQLObjectType'].concat(imports.filter(isGraphQL));
+    var others = imports.filter(not(isGraphQL));
+
+    return (
+        opts.es6 ?
+        es6Import(graphql, others, opts) :
+        cjsImport(graphql, others, opts)
+    );
+}
+
+function cjsImport(graphql, others, opts) {
+    var declarations = [];
+
+    if (graphql.length) {
+        declarations.push(b.variableDeclaration('var',
+            [b.variableDeclarator(
+                b.identifier('GraphQL'),
+                b.callExpression(
+                    b.identifier('require'),
+                    [b.literal('graphql')]
+                )
+            )]
+        ));
+
+        graphql.forEach(function(item) {
+            declarations.push(
+                b.variableDeclaration('var',
+                    [b.variableDeclarator(
+                        b.identifier(item),
+                        b.memberExpression(
+                            b.identifier('GraphQL'),
+                            b.identifier(item),
+                            false
+                        )
+                    )]
+                ));
+        });
+    }
+
+    if (others.length && !opts.skipLocalImports) {
+        others.forEach(function(item) {
+            declarations.push(
+                b.variableDeclaration('var',
+                    [b.variableDeclarator(
+                        b.identifier(item),
+                        b.callExpression(
+                            b.identifier('require'),
+                            [b.literal(importPath(item, opts))]
+                        )
+                    )]
+                ));
+        });
+    }
+
+    return declarations;
+}
+
+function es6Import(graphql, others, opts) {
+    var declarations = [];
+    if (graphql.length) {
+        declarations.push(b.importDeclaration(
+            graphql.map(importSpecifier),
+            b.literal('graphql')
+        ));
+    }
+
+    if (others.length && !opts.skipLocalImports) {
+        declarations = declarations.concat(
+            others.map(function(item) {
+                return importDeclaration(item, opts);
+            })
+        );
+    }
+
+    return declarations;
+}
+
+// Couldn't figure out b.importSpecifier
+function importSpecifier(name) {
+    return {
+        type: 'ImportSpecifier',
+        id: {
+            type: 'Identifier',
+            name: name
+        },
+        name: null
+    };
+}
+
+function importDeclaration(item, opts) {
+    return b.importDeclaration(
+        [importSpecifier(item)],
+        b.literal(importPath(item, opts))
+    );
+}
+
+function importPath(item, opts) {
+    return path.join(opts.outputDir, 'types', item);
+}
+
+function isGraphQL(name) {
+    return name.indexOf('GraphQL') === 0;
+}
+
+function not(fn) {
+    return function(item) {
+        return !fn(item);
+    };
+}
+
+module.exports = generateImports;

--- a/util/print-ast.js
+++ b/util/print-ast.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var recast = require('recast');
+var cardinal = require('cardinal');
+
+module.exports = function printAst(ast, opts) {
+    var code = recast.prettyPrint(ast, opts).code;
+
+    console.log(
+        opts.colors ?
+        cardinal.highlight(code) :
+        code
+    );
+};


### PR DESCRIPTION
This PR adds support for generating the graphql types. Initial ES6/CommonJS style selection is in place.

Going forward, I will try to split the types into individual files if `--output-dir` is set.

`sql2graphql --host=somehost --user=someuser --password=somepass --db=somedb > my-types.js` will give you something to work with.