### PR TITLE
Fixes for the console output of the schema

### DIFF
--- a/steps/ast-builders/program.js
+++ b/steps/ast-builders/program.js
@@ -21,7 +21,7 @@ module.exports = function buildProgram(data, opts) {
         .concat(buildImports(imports, options))
         .concat(typesAst)
         .concat([buildSchema(data, options)])
-        .concat([buildSchemaExport(data, options)]);
+        .concat([buildSchemaExport(options)]);
 
     return b.program(program);
 };

--- a/steps/ast-builders/query.js
+++ b/steps/ast-builders/query.js
@@ -9,7 +9,7 @@ var typeMap = {
     'float': 'GraphQLFloat'
 };
 
-module.exports = function buildQuery(type, data) {
+module.exports = function buildQuery(type, data, opts) {
     var model = data.models[type.name];
     var primaryKey = getPrimaryKey(model) || {};
     var keyName = primaryKey.name;
@@ -17,11 +17,6 @@ module.exports = function buildQuery(type, data) {
 
     return b.objectExpression([
         b.property('init', b.identifier('type'), b.identifier(type.varName)),
-        b.property(
-            'init',
-            b.identifier('resolve'),
-            buildResolver(type, data)
-        ),
         b.property('init', b.identifier('args'), b.objectExpression(keyName ? [
             b.property('init', b.identifier('id'), b.objectExpression([
                 b.property('init', b.identifier('name'), b.literal(keyName)),
@@ -31,7 +26,11 @@ module.exports = function buildQuery(type, data) {
                 ))
             ]))
         ] : []))
-    ]);
+    ].concat(opts.outputDir ? [b.property(
+        'init',
+        b.identifier('resolve'),
+        buildResolver(type, data)
+    )] : []));
 };
 
 

--- a/steps/ast-builders/schema.js
+++ b/steps/ast-builders/schema.js
@@ -6,7 +6,7 @@ var b = require('ast-types').builders;
 var buildVar = require('./variable');
 var buildQuery = require('./query');
 
-module.exports = function(data) {
+module.exports = function(data, opts) {
     return buildVar('schema',
         b.newExpression(
             b.identifier('GraphQLSchema'),
@@ -23,7 +23,7 @@ module.exports = function(data) {
                                     return b.property(
                                         'init',
                                         b.identifier(camelCase(type.name)),
-                                        buildQuery(type, data)
+                                        buildQuery(type, data, opts)
                                     );
                                 })
                             ))

--- a/steps/generate-types.js
+++ b/steps/generate-types.js
@@ -122,7 +122,7 @@ function generateTypes(data, opts) {
         return generateField({
             name: refersTo.field,
             description: description,
-            resolve: buildResolver(refersTo.model, data, refField.originalName)
+            resolve: opts.outputDir && buildResolver(refersTo.model, data, refField.originalName)
         }, b.identifier(refTypeName));
     }
 


### PR DESCRIPTION
Had some regressions when it came to the console output of the app. This should ensure both ES6 and ES5 versions are output correctly when not using outputDir.