### PR TITLE
Add support for Relay Node field

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This utility is intended to help people get started with GraphQL. It is **NOT** 
   - `--password`, `-p` - Password to use when connecting *`(string [default: ""])`*
   - `--table`, `-t` - Tables to generate type schemas for *`(array [default: "*"])`*
   - `--backend`, `-b` - Type of database *`(string [default: "mysql"])`*
+  - `--relay`, `-r` - Generate Relay-style schema *`(boolean [default: false])`*
   - `--strip-suffix` - Remove a suffix from table names when generating types *`(array)`*
   - `--strip-prefix` - Remove a prefix from table names when generating types *`(array)`*
   - `--interactive`, `-i` - Interactive mode *`(boolean [default: false])`*

--- a/cli.js
+++ b/cli.js
@@ -25,6 +25,9 @@ var steps = {
 opts.command = (opts._ || [])[0];
 opts.user = opts.backend !== 'mysql' && opts.user === 'root' ? (process.env.USER || 'root') : opts.user;
 
+// Force recast to throw away whitespace information
+opts.reuseWhitespace = false;
+
 var commands = ['app', 'print'];
 if (!opts.command || !opts.command.length) {
     return bail(new Error('Please specify command to run - `sql2graphql [' + commands.join(' | ') + ']`'));

--- a/cli/args.js
+++ b/cli/args.js
@@ -46,6 +46,11 @@ module.exports = require('yargs')
         type: 'string',
         'default': 'mysql'
     })
+    .option('relay', {
+        alias: 'r',
+        describe: 'Generate Relay-style schema',
+        type: 'boolean'
+    })
     .option('strip-suffix', {
         describe: 'Remove a suffix from table names when generating',
         type: 'array'

--- a/steps/ast-builders/imports.js
+++ b/steps/ast-builders/imports.js
@@ -50,6 +50,21 @@ function cjsImport(graphql, others, opts) {
                 )
             )]
         ));
+
+        declarations.push(b.variableDeclaration('var',
+            [b.variableDeclarator(
+                b.identifier('registerType'),
+
+                b.memberExpression(
+                    b.callExpression(
+                        b.identifier('require'),
+                        [b.literal('./resolve-map')]
+                    ),
+                    b.identifier('registerType'),
+                    false
+                )
+            )]
+        ));
     }
 
     if (others.length && !opts.skipLocalImports) {
@@ -82,17 +97,19 @@ function cjsImport(graphql, others, opts) {
     });
 
     if (opts.relay && opts.isFromSchema) {
-        declarations.push(
-            b.variableDeclaration('var',
-                [b.variableDeclarator(
-                    b.identifier('globalIdField'),
-                    b.memberExpression(
-                        b.identifier('GraphRelay'),
-                        b.identifier('globalIdField'),
-                        false
-                    )
-                )]
-            )
+        declarations = declarations.concat(
+            ['globalIdField', 'nodeDefinitions', 'fromGlobalId'].map(function(rg) {
+                return b.variableDeclaration('var',
+                    [b.variableDeclarator(
+                        b.identifier(rg),
+                        b.memberExpression(
+                            b.identifier('GraphRelay'),
+                            b.identifier(rg),
+                            false
+                        )
+                    )]
+                );
+            })
         );
     }
 
@@ -110,17 +127,20 @@ function es6Import(graphql, others, opts) {
 
     if (graphql.length) {
         declarations.push(b.importDeclaration(
-            graphql.map(function(item) {
-                return importSpecifier(item);
-            }),
+            graphql.map(importSpecifier),
             b.literal('graphql')
         ));
     }
 
     if (opts.relay && opts.isFromSchema) {
         declarations.push(b.importDeclaration(
-            [importSpecifier('globalIdField')],
+            ['globalIdField', 'nodeDefinitions', 'fromGlobalId'].map(importSpecifier),
             b.literal('graphql-relay')
+        ));
+
+        declarations.push(b.importDeclaration(
+            [importSpecifier('registerType')],
+            b.literal('./resolve-map')
         ));
     }
 
@@ -138,7 +158,7 @@ function es6Import(graphql, others, opts) {
 // Couldn't figure out b.importSpecifier
 function importSpecifier(name, def) {
     return {
-        type: def ? 'ImportDefaultSpecifier' : 'ImportSpecifier',
+        type: def === true ? 'ImportDefaultSpecifier' : 'ImportSpecifier',
         id: {
             type: 'Identifier',
             name: name

--- a/steps/ast-builders/imports.js
+++ b/steps/ast-builders/imports.js
@@ -40,6 +40,18 @@ function cjsImport(graphql, others, opts) {
         ));
     }
 
+    if (opts.relay && opts.isFromSchema) {
+        declarations.push(b.variableDeclaration('var',
+            [b.variableDeclarator(
+                b.identifier('GraphRelay'),
+                b.callExpression(
+                    b.identifier('require'),
+                    [b.literal('graphql-relay')]
+                )
+            )]
+        ));
+    }
+
     if (others.length && !opts.skipLocalImports) {
         others.forEach(function(item) {
             declarations.push(
@@ -69,6 +81,21 @@ function cjsImport(graphql, others, opts) {
             ));
     });
 
+    if (opts.relay && opts.isFromSchema) {
+        declarations.push(
+            b.variableDeclaration('var',
+                [b.variableDeclarator(
+                    b.identifier('globalIdField'),
+                    b.memberExpression(
+                        b.identifier('GraphRelay'),
+                        b.identifier('globalIdField'),
+                        false
+                    )
+                )]
+            )
+        );
+    }
+
     return declarations;
 }
 
@@ -87,6 +114,13 @@ function es6Import(graphql, others, opts) {
                 return importSpecifier(item);
             }),
             b.literal('graphql')
+        ));
+    }
+
+    if (opts.relay && opts.isFromSchema) {
+        declarations.push(b.importDeclaration(
+            [importSpecifier('globalIdField')],
+            b.literal('graphql-relay')
         ));
     }
 

--- a/steps/ast-builders/node-definitions.js
+++ b/steps/ast-builders/node-definitions.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var recast = require('recast');
+
+module.exports = function buildNodeDefinitions(opts) {
+    var tplPath = path.join(__dirname, 'templates');
+    var tpl = opts.es6 ? 'node-def-es6.js' : 'node-def-cjs.js';
+    var ast = recast.parse(fs.readFileSync(path.join(tplPath, tpl))).program.body;
+
+    return ast;
+};

--- a/steps/ast-builders/object.js
+++ b/steps/ast-builders/object.js
@@ -1,12 +1,27 @@
 'use strict';
 
 var b = require('ast-types').builders;
+var isPlainObject = require('lodash/lang/isPlainObject');
 
-module.exports = function buildObject(obj) {
-    var fields = [];
-    for (var key in obj) {
-        fields.push(b.property('init', b.literal(key), b.literal(obj[key])));
+function buildObject(obj) {
+    var fields = [], key;
+    for (key in obj) {
+        fields.push(b.property('init', b.literal(key), castValue(obj[key])));
     }
 
     return b.objectExpression(fields);
-};
+}
+
+function castValue(val) {
+    if (isPlainObject(val)) {
+        return buildObject(val);
+    } else if (val === null) {
+        return b.identifier('null');
+    } else if (typeof val === 'undefined') {
+        return b.identifier('undefined');
+    }
+
+    return b.literal(val);
+}
+
+module.exports = buildObject;

--- a/steps/ast-builders/program.js
+++ b/steps/ast-builders/program.js
@@ -10,17 +10,30 @@ var buildImports = require('./imports');
 var buildSchema = require('./schema');
 var buildStrict = require('./use-strict');
 var buildSchemaExport = require('./exports-schema');
+var buildNodeDefs = require('./node-definitions');
 
 module.exports = function buildProgram(data, opts) {
     var options = merge({ skipLocalImports: !opts.outputDir }, opts);
     var imports = uniq(flatten(pluck(data.types, 'imports')));
     var typesAst = pluck(sortBy(data.types, 'imports.length'), 'ast');
+    var nodeDefs = opts.relay ? buildNodeDefs(opts) : [];
+    var beforeExport = [];
+
+    if (opts.relay) {
+        var typeVars = pluck(data.types, 'varName').map(b.identifier);
+        beforeExport = [b.expressionStatement(b.callExpression(
+            b.memberExpression(b.arrayExpression(typeVars), b.identifier('forEach'), false),
+            [b.identifier('registerType')]
+        ))];
+    }
 
     var program = []
         .concat(buildStrict(options))
         .concat(buildImports(imports, options))
+        .concat(nodeDefs)
         .concat(typesAst)
         .concat([buildSchema(data, options)])
+        .concat(beforeExport)
         .concat([buildSchemaExport(options)]);
 
     return b.program(program);

--- a/steps/ast-builders/resolve-map.js
+++ b/steps/ast-builders/resolve-map.js
@@ -1,0 +1,220 @@
+'use strict';
+
+var b = require('ast-types').builders;
+var reduce = require('lodash/collection/reduce');
+var buildObject = require('./object');
+var buildStrict = require('./use-strict');
+var buildVariable = require('./variable');
+var getPrimaryKey = require('../../util/get-primary-key');
+
+module.exports = function buildResolveMap(data, opts) {
+    var map = getResolveMap(data.models, opts);
+
+    var program = []
+        .concat(buildStrict(opts))
+        .concat(buildResolveMapExport(map, opts))
+        .concat(buildTypeRegisterFunc(opts));
+
+    return b.program(program);
+};
+
+function getResolveMap(models, opts) {
+    var resolveMap = {};
+    for (var type in models) {
+        resolveMap[models[type].name] = getTypeResolver(models[type], opts);
+    }
+
+    return buildObject(resolveMap, opts);
+}
+
+function getTypeResolver(model) {
+    return {
+        name: model.name,
+        table: model.table,
+        primaryKey: getPrimaryKeyArg(model),
+        aliases: model.aliasedFields,
+        referenceMap: getRefFieldMapArg(model)
+    };
+}
+
+function getRefFieldMapArg(model) {
+    return reduce(model.references, buildReferenceMap, {});
+}
+
+function getPrimaryKeyArg(model) {
+    var primaryKey = getPrimaryKey(model);
+    return primaryKey ? primaryKey.originalName : null;
+}
+
+function buildReferenceMap(refMap, reference) {
+    refMap[reference.field] = reference.refField;
+    return refMap;
+}
+
+function buildResolveMapExport(map, opts) {
+    if (opts.es6) {
+        return [b.exportDeclaration(false, buildVariable('resolveMap', map, opts.es6))];
+    }
+
+    return [
+        buildVariable('resolveMap', map, opts.es6),
+        b.expressionStatement(
+            b.assignmentExpression(
+                '=',
+                b.memberExpression(
+                    b.identifier('exports'),
+                    b.identifier('resolveMap'),
+                    false
+                ),
+                b.identifier('resolveMap')
+            )
+        )
+    ];
+}
+
+function buildTypeRegisterFunc(opts) {
+    var func = (opts.es6 ? b.functionDeclaration : b.functionExpression)(
+        b.identifier('registerType'),
+        [b.identifier('type')],
+        b.blockStatement(getTypeRegisterAst())
+    );
+
+    if (opts.es6) {
+        return [b.exportDeclaration(false, func)];
+    }
+
+    return [
+        b.expressionStatement(b.assignmentExpression(
+            '=',
+            b.memberExpression(
+                b.identifier('exports'),
+                b.identifier('registerType'),
+                false
+            ),
+            func
+        ))
+    ];
+}
+
+// Can't be bothered trying replicate this with the builder right now :x
+// On a totally unrelated side-note, someone should make a thing that takes
+// AST and generates code that can build it with the `ast-types` builder
+// Then you would be able to easily make parts of it dynamic etc. Much like
+// this project, I guess.
+function getTypeRegisterAst() {
+    return [
+        {
+            'type': 'IfStatement',
+            'test': {
+                'type': 'UnaryExpression',
+                'operator': '!',
+                'argument': {
+                    'type': 'MemberExpression',
+                    'computed': true,
+                    'object': {
+                        'type': 'Identifier',
+                        'name': 'resolveMap'
+                    },
+                    'property': {
+                        'type': 'MemberExpression',
+                        'computed': false,
+                        'object': {
+                            'type': 'Identifier',
+                            'name': 'type'
+                        },
+                        'property': {
+                            'type': 'Identifier',
+                            'name': 'name'
+                        }
+                    }
+                },
+                'prefix': true
+            },
+            'consequent': {
+                'type': 'BlockStatement',
+                'body': [
+                    {
+                        'type': 'ThrowStatement',
+                        'argument': {
+                            'type': 'NewExpression',
+                            'callee': {
+                                'type': 'Identifier',
+                                'name': 'Error'
+                            },
+                            'arguments': [
+                                {
+                                    'type': 'BinaryExpression',
+                                    'operator': '+',
+                                    'left': {
+                                        'type': 'BinaryExpression',
+                                        'operator': '+',
+                                        'left': {
+                                            'type': 'Literal',
+                                            'value': 'Cannot register type "'
+                                        },
+                                        'right': {
+                                            'type': 'MemberExpression',
+                                            'computed': false,
+                                            'object': {
+                                                'type': 'Identifier',
+                                                'name': 'type'
+                                            },
+                                            'property': {
+                                                'type': 'Identifier',
+                                                'name': 'name'
+                                            }
+                                        }
+                                    },
+                                    'right': {
+                                        'type': 'Literal',
+                                        'value': '" - resolve map does not exist for that type'
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            'alternate': null
+        },
+        {
+            'type': 'ExpressionStatement',
+            'expression': {
+                'type': 'AssignmentExpression',
+                'operator': '=',
+                'left': {
+                    'type': 'MemberExpression',
+                    'computed': false,
+                    'object': {
+                        'type': 'MemberExpression',
+                        'computed': true,
+                        'object': {
+                            'type': 'Identifier',
+                            'name': 'resolveMap'
+                        },
+                        'property': {
+                            'type': 'MemberExpression',
+                            'computed': false,
+                            'object': {
+                                'type': 'Identifier',
+                                'name': 'type'
+                            },
+                            'property': {
+                                'type': 'Identifier',
+                                'name': 'name'
+                            }
+                        }
+                    },
+                    'property': {
+                        'type': 'Identifier',
+                        'name': 'type'
+                    }
+                },
+                'right': {
+                    'type': 'Identifier',
+                    'name': 'type'
+                }
+            }
+        }
+    ];
+}

--- a/steps/ast-builders/resolver.js
+++ b/steps/ast-builders/resolver.js
@@ -1,52 +1,11 @@
 'use strict';
 
 var b = require('ast-types').builders;
-var reduce = require('lodash/collection/reduce');
-var getPrimaryKey = require('../../util/get-primary-key');
-var buildObject = require('./object');
 
-module.exports = function buildResolver(type, data, referingField) {
-    var model = data.models[type.name];
-
+module.exports = function buildResolver(model, refField) {
+    var ref = refField ? [b.literal(refField)] : [];
     return b.callExpression(
         b.identifier('getEntityResolver'),
-        [buildResolverArg()]
+        [b.literal(model.name)].concat(ref)
     );
-
-    function buildResolverArg() {
-        return b.objectExpression([
-            b.property('init', b.identifier('table'), b.literal(model.table)),
-            b.property('init', b.identifier('primaryKey'), getPrimaryKeyArg()),
-            b.property('init', b.identifier('aliases'), buildObject(model.aliasedFields)),
-            b.property('init', b.identifier('reference'), getReferenceArg()),
-            b.property('init', b.identifier('referenceMap'), getRefFieldMapArg())
-        ]);
-    }
-
-    function getRefFieldMapArg() {
-        if (referingField) {
-            return b.identifier('null');
-        }
-
-        var referenceMap = reduce(model.references, buildReferenceMap, {});
-        return buildObject(referenceMap);
-    }
-
-    function getPrimaryKeyArg() {
-        var primaryKey = getPrimaryKey(model);
-        return primaryKey ?
-            b.literal(primaryKey.originalName) :
-            b.identifier('null');
-    }
-
-    function getReferenceArg() {
-        return referingField ?
-            b.literal(referingField) :
-            b.identifier('null');
-    }
 };
-
-function buildReferenceMap(refMap, reference) {
-    refMap[reference.field] = reference.refField;
-    return refMap;
-}

--- a/steps/ast-builders/schema.js
+++ b/steps/ast-builders/schema.js
@@ -8,6 +8,23 @@ var buildQuery = require('./query');
 var buildFieldWrapperFunction = require('./field-wrapper-function');
 
 module.exports = function(data, opts) {
+    var queryFields = [];
+    if (opts.relay) {
+        queryFields.push(b.property(
+            'init',
+            b.identifier('node'),
+            b.identifier('nodeField')
+        ));
+    } else {
+        queryFields = map(data.types, function(type) {
+            return b.property(
+                'init',
+                b.identifier(camelCase(type.name)),
+                buildQuery(type, data, opts)
+            );
+        });
+    }
+
     return buildVar('schema',
         b.newExpression(
             b.identifier('GraphQLSchema'),
@@ -21,15 +38,7 @@ module.exports = function(data, opts) {
                             b.property('init', b.identifier('name'), b.literal('RootQueryType')),
                             b.property('init', b.identifier('fields'), buildFieldWrapperFunction(
                                 'RootQuery',
-                                b.objectExpression(
-                                    map(data.types, function(type) {
-                                        return b.property(
-                                            'init',
-                                            b.identifier(camelCase(type.name)),
-                                            buildQuery(type, data, opts)
-                                        );
-                                    })
-                                ),
+                                b.objectExpression(queryFields),
                                 opts
                             ))
                         ])]

--- a/steps/ast-builders/templates/node-def-cjs.js
+++ b/steps/ast-builders/templates/node-def-cjs.js
@@ -2,7 +2,7 @@ var node = nodeDefinitions(
     function(globalId, ast) {
         var gid = fromGlobalId(globalId);
         var fieldKind = gid.id.match(/^[0-9]+$/) ? 'IntValue' : 'StringValue';
-        var override = { arguments: [{ name: { value: 'id' }, value: { value: id, kind: fieldKind } }] };
+        var override = { arguments: [{ name: { value: 'id' }, value: { value: gid.id, kind: fieldKind } }] };
         return getEntityResolver(gid.type)(null, {}, ast, override);
     },
     function(data) {

--- a/steps/ast-builders/templates/node-def-cjs.js
+++ b/steps/ast-builders/templates/node-def-cjs.js
@@ -1,0 +1,14 @@
+var node = nodeDefinitions(
+    function(globalId, ast) {
+        var gid = fromGlobalId(globalId);
+        var fieldKind = gid.id.match(/^[0-9]+$/) ? 'IntValue' : 'StringValue';
+        var override = { arguments: [{ name: { value: 'id' }, value: { value: id, kind: fieldKind } }] };
+        return getEntityResolver(gid.type)(null, {}, ast, override);
+    },
+    function(data) {
+        return data.__type;
+    }
+);
+
+var nodeInterface = node.nodeInterface;
+var nodeField = node.nodeField;

--- a/steps/ast-builders/templates/node-def-es6.js
+++ b/steps/ast-builders/templates/node-def-es6.js
@@ -1,0 +1,9 @@
+const {nodeInterface, nodeField} = nodeDefinitions(
+    function(globalId, ast) {
+        var {type, id} = fromGlobalId(globalId);
+        var fieldKind = id.match(/^[0-9]+$/) ? 'IntValue' : 'StringValue';
+        var override = { arguments: [{ name: { value: 'id' }, value: { value: id, kind: fieldKind } }] };
+        return getEntityResolver(type)(null, {}, ast, override);
+    },
+    data => data.__type
+);

--- a/steps/output-data.js
+++ b/steps/output-data.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var merge = require('lodash/object/merge');
 var recast = require('recast');
 var mkdirp = require('mkdirp');
 var printAst = require('../util/print-ast');
@@ -12,6 +13,10 @@ var buildSchemaModule = require('./ast-builders/schema-module');
 var copyTemplates = require('./copy-templates');
 
 function outputData(data, opts, callback) {
+    if (opts.relay) {
+        opts = merge({}, opts, { isFromSchema: true });
+    }
+
     if (!opts.outputDir) {
         printAst(
             buildProgram(data, opts),

--- a/steps/output-data.js
+++ b/steps/output-data.js
@@ -11,6 +11,7 @@ var buildConfig = require('./ast-builders/config');
 var buildProgram = require('./ast-builders/program');
 var buildResolveMap = require('./ast-builders/resolve-map');
 var buildSchemaModule = require('./ast-builders/schema-module');
+var updatePackageManifest = require('./update-package');
 var copyTemplates = require('./copy-templates');
 
 function outputData(data, opts, callback) {
@@ -74,6 +75,9 @@ function outputData(data, opts, callback) {
 
         // Copy templates ("static" ones, should probably be named something else)
         copyTemplates(opts.es6 ? 'es6' : 'cjs', outputDir);
+
+        // Update package.json file with any necessary changes
+        updatePackageManifest(opts);
 
         callback();
     });

--- a/steps/output-data.js
+++ b/steps/output-data.js
@@ -25,36 +25,45 @@ function outputData(data, opts, callback) {
     var outputDir = path.resolve(opts.outputDir);
     var typesDir = path.join(outputDir, 'types');
     var configDir = path.join(outputDir, 'config');
-    mkdirp(typesDir, function(err) {
+    mkdirp(configDir, function(err) {
         if (err) {
             throw err;
         }
 
         // Write the configuration file
-        mkdirp(configDir, function(configErr) {
-            if (configErr) {
-                throw configErr;
-            }
+        var conf = recast.prettyPrint(buildConfig(opts), opts).code;
+        fs.writeFileSync(path.join(configDir, 'config.js'), conf);
 
-            var conf = recast.prettyPrint(buildConfig(opts), opts).code;
-            fs.writeFileSync(path.join(configDir, 'config.js'), conf);
-        });
+        // Relay-style or regular GraphQL?
+        if (opts.relay) {
+            // @todo Not splitting types into individual modules for relay because of
+            // circular dependencies + interfaces which are required at definition-type.
+            // Obviously we should find a solution to this and split stuff up.
+            var schema = recast.prettyPrint(buildProgram(data, opts), opts).code;
+            fs.writeFileSync(path.join(outputDir, 'schema.js'), schema);
+        } else {
+            mkdirp(typesDir, function(typesErr) {
+                if (typesErr) {
+                    throw typesErr;
+                }
+
+                // Write types
+                var type, ast, code;
+                for (type in data.types) {
+                    ast = buildType(data.types[type], opts);
+                    code = recast.prettyPrint(ast, opts).code;
+
+                    fs.writeFileSync(path.join(typesDir, data.types[type].varName + '.js'), code);
+                }
+
+                // Write the schema!
+                code = recast.prettyPrint(buildSchemaModule(data, opts), opts).code;
+                fs.writeFileSync(path.join(outputDir, 'schema.js'), code);
+            });
+        }
 
         // Copy templates ("static" ones, should probably be named something else)
         copyTemplates(opts.es6 ? 'es6' : 'cjs', outputDir);
-
-        // Write types
-        var type, ast, code;
-        for (type in data.types) {
-            ast = buildType(data.types[type], opts);
-            code = recast.prettyPrint(ast, opts).code;
-
-            fs.writeFileSync(path.join(typesDir, data.types[type].varName + '.js'), code);
-        }
-
-        // Write the all-important schema!
-        code = recast.prettyPrint(buildSchemaModule(data, opts), opts).code;
-        fs.writeFileSync(path.join(outputDir, 'schema.js'), code);
 
         callback();
     });

--- a/steps/output-data.js
+++ b/steps/output-data.js
@@ -9,6 +9,7 @@ var printAst = require('../util/print-ast');
 var buildType = require('./ast-builders/type');
 var buildConfig = require('./ast-builders/config');
 var buildProgram = require('./ast-builders/program');
+var buildResolveMap = require('./ast-builders/resolve-map');
 var buildSchemaModule = require('./ast-builders/schema-module');
 var copyTemplates = require('./copy-templates');
 
@@ -66,6 +67,10 @@ function outputData(data, opts, callback) {
                 fs.writeFileSync(path.join(outputDir, 'schema.js'), code);
             });
         }
+
+        // Build and write the resolve map
+        var resolveMap = recast.prettyPrint(buildResolveMap(data, opts), opts).code;
+        fs.writeFileSync(path.join(outputDir, 'resolve-map.js'), resolveMap);
 
         // Copy templates ("static" ones, should probably be named something else)
         copyTemplates(opts.es6 ? 'es6' : 'cjs', outputDir);

--- a/steps/update-package.js
+++ b/steps/update-package.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function updatePackageJson(opts) {
+    var pkgPath = path.join(opts.outputDir, 'package.json');
+    var pkgFile = fs.readFileSync(pkgPath);
+    var pkgContent = JSON.parse(pkgFile);
+
+    if (opts.relay) {
+        pkgContent.dependencies['graphql-relay'] = '^0.3.0';
+    }
+
+    fs.writeFileSync(pkgPath, JSON.stringify(pkgContent, null, 2));
+};

--- a/templates/cjs/package.json
+++ b/templates/cjs/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "boom": "^2.8.0",
-    "graphql": "^0.2.6",
+    "graphql": "^0.4.2",
     "hapi": "^8.8.1",
     "knex": "^0.8.6",
     "mysql": "^2.8.0"

--- a/templates/cjs/util/entity-resolver.js
+++ b/templates/cjs/util/entity-resolver.js
@@ -38,7 +38,10 @@ function getResolver(type) {
         var query = (
             isList ? db().select(selection) : db().first(selection)
         ).from(typeData.table).where(clauses).then(function(result) {
-            result.__type = typeData.type;
+            if (result) {
+                result.__type = typeData.type;
+            }
+
             return result;
         });
 

--- a/templates/es6/package.json
+++ b/templates/es6/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "babel": "^5.8.20",
     "boom": "^2.8.0",
-    "graphql": "^0.2.6",
+    "graphql": "^0.4.2",
     "hapi": "^8.8.1",
     "knex": "^0.8.6",
     "mysql": "^2.8.0"

--- a/templates/es6/util/entity-resolver.js
+++ b/templates/es6/util/entity-resolver.js
@@ -6,7 +6,7 @@ export default function getResolver(opts) {
     return function resolveEntity(parent, args, src, ast, type) {
         const isList = type instanceof GraphQLList;
         const clauses = getClauses(ast, opts.aliases);
-        const selection = getSelectionSet(ast, opts.aliases, opts.referenceMap);
+        const selection = getSelectionSet(type, ast, opts.aliases, opts.referenceMap);
         const hasPkSelected = (
             opts.primaryKey &&
             selection.some(item => item.indexOf(opts.primaryKey) === 0)
@@ -28,16 +28,24 @@ export default function getResolver(opts) {
     };
 }
 
-function getSelectionSet(ast, aliases, referenceMap) {
+function getSelectionSet(type, ast, aliases, referenceMap) {
     return ast.selectionSet.selections.reduce(function reduceSelectionSet(set, selection) {
-        let alias, field;
 
-        // For fields with its own selection set, we need to fetch the reference ID
-        if (selection.selectionSet && referenceMap) {
+        // If we encounter a selection with a type condition, make sure it's the correct type
+        if (selection.typeCondition && selection.typeCondition.name.value !== type) {
+            return set;
+        }
+
+        let alias, field;
+        if (selection.kind === 'Field' && selection.selectionSet && referenceMap) {
+            // For fields with its own selection set, we need to fetch the reference ID
             alias = referenceMap[selection.name.value];
             field = getUnaliasedName(alias, aliases);
             set.push(field || alias);
             return set;
+        } else if (selection.kind === 'InlineFragment' && selection.selectionSet) {
+            // And for inline fragments, we need to recurse down and combine the set
+            return set.concat(getSelectionSet(type, selection, aliases, referenceMap));
         } else if (selection.selectionSet) {
             return set;
         }


### PR DESCRIPTION
This PR introduces basic support for Relay's Node field, which turns the `id` field into a globally unique ID. Closes #13 and #14.