### PR TITLE
Fix duplicate enum names in schema

### DIFF
--- a/steps/ast-builders/query.js
+++ b/steps/ast-builders/query.js
@@ -29,7 +29,7 @@ module.exports = function buildQuery(type, data, opts) {
     ].concat(opts.outputDir ? [b.property(
         'init',
         b.identifier('resolve'),
-        buildResolver(type, data)
+        buildResolver(type)
     )] : []));
 };
 

--- a/steps/ast-builders/resolver.js
+++ b/steps/ast-builders/resolver.js
@@ -2,10 +2,9 @@
 
 var b = require('ast-types').builders;
 
-module.exports = function buildResolver(model, refField) {
-    var ref = refField ? [b.literal(refField)] : [];
+module.exports = function buildResolver(model) {
     return b.callExpression(
         b.identifier('getEntityResolver'),
-        [b.literal(model.name)].concat(ref)
+        [b.literal(model.name)]
     );
 };


### PR DESCRIPTION
This PR fixes (half) of #22 - it makes sure that enums are prefixed with their type, so they don't collide. I'd love to also try and detect actual, duplicate enums at some point and reuse them across types, but I'll save that for later.