### PR TITLE
Use literals for enum property names

### DIFF
--- a/steps/generate-types.js
+++ b/steps/generate-types.js
@@ -151,7 +151,7 @@ function generateTypes(data, opts) {
             enumValue = field.values[name];
             values.push(b.property(
                 'init',
-                b.identifier(snakeCase(name).toUpperCase()),
+                b.literal(snakeCase(name).toUpperCase()),
                 b.objectExpression([
                     b.property('init', b.identifier('value'), b.literal(enumValue.value)),
                     generateDescription(enumValue.description)


### PR DESCRIPTION
Some enum values I encountered have names that are not valid as identifiers, eg `2x2`. This change uses literals instead to ensure they always work as keys.